### PR TITLE
add Rustlang.Rust.GNU and Rustlang.Rust.MSVC

### DIFF
--- a/tasks/json/Rustlang.Rust.GNU.json
+++ b/tasks/json/Rustlang.Rust.GNU.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "rust-lang", "repo": "rust" },
+	"urls": [
+		"https://static.rust-lang.org/dist/rust-{version}-i686-pc-windows-gnu.msi",
+		"https://static.rust-lang.org/dist/rust-{version}-x86_64-pc-windows-gnu.msi"
+	],
+	"releaseNotes": {
+		"source": "github",
+		"tag": "{version}"
+	}
+}

--- a/tasks/json/Rustlang.Rust.MSVC.json
+++ b/tasks/json/Rustlang.Rust.MSVC.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "rust-lang", "repo": "rust" },
+	"urls": [
+		"https://static.rust-lang.org/dist/rust-{version}-aarch64-pc-windows-msvc.msi",
+		"https://static.rust-lang.org/dist/rust-{version}-i686-pc-windows-msvc.msi",
+		"https://static.rust-lang.org/dist/rust-{version}-x86_64-pc-windows-msvc.msi"
+	],
+	"releaseNotes": {
+		"source": "github",
+		"tag": "{version}"
+	}
+}


### PR DESCRIPTION
Closes #375 

As proposed, this adds the Rustlang.Rust.GNU and Rustlang.Rust.MSVC packages to this bot's package list.